### PR TITLE
Create admin role to use EC2 attachement.

### DIFF
--- a/terraform/iam/art-id/admin.tf
+++ b/terraform/iam/art-id/admin.tf
@@ -1,0 +1,57 @@
+resource "aws_iam_role" "admin" {
+  name               = "admin"
+  path               = "/"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+
+}
+
+resource "aws_iam_role_policy" "admin" {
+  name   = "admin-policy"
+  role   = aws_iam_role.admin.id
+  policy = <<EOF
+{
+  "Statement": [
+    {
+      "Sid": "AllowAppArtifactsReadAccess",
+      "Action": [
+        "*"
+      ],
+      "Resource": [
+        "*"
+      ],
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+
+}
+
+
+resource "aws_iam_instance_profile" "admin" {
+  name = "admin-profile"
+  role = aws_iam_role.admin.name
+}
+
+resource "aws_iam_role_policy_attachment" "admin_attach" {
+  role       = aws_iam_role.admin.name
+  policy_arn = aws_iam_policy.app_universal.arn
+}
+
+output "admin_instance_profile" {
+  value = aws_iam_instance_profile.admin.arn
+}


### PR DESCRIPTION
```
  + create

Terraform will perform the following actions:

  # aws_iam_instance_profile.admin will be created
  + resource "aws_iam_instance_profile" "admin" {
      + arn         = (known after apply)
      + create_date = (known after apply)
      + id          = (known after apply)
      + name        = "admin-profile"
      + path        = "/"
      + role        = "admin"
      + unique_id   = (known after apply)
    }

  # aws_iam_role.admin will be created
  + resource "aws_iam_role" "admin" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "ec2.amazonaws.com"
                        }
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + max_session_duration  = 3600
      + name                  = "admin"
      + path                  = "/"
      + unique_id             = (known after apply)
    }

  # aws_iam_role_policy.admin will be created
  + resource "aws_iam_role_policy" "admin" {
      + id     = (known after apply)
      + name   = "admin-policy"
      + policy = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = [
                          + "*",
                        ]
                      + Effect   = "Allow"
                      + Resource = [
                          + "*",
                        ]
                      + Sid      = "AllowAppArtifactsReadAccess"
                    },
                ]
            }
        )
      + role   = (known after apply)
    }

  # aws_iam_role_policy_attachment.admin_attach will be created
  + resource "aws_iam_role_policy_attachment" "admin_attach" {
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::816736805842:policy/app-universal"
      + role       = "admin"
    }

Plan: 4 to add, 0 to change, 0 to destroy.
```
